### PR TITLE
Matsuda

### DIFF
--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -15,7 +15,7 @@
 				<% if @orders.exists? %>
 					<% @orders.each do |order| %>
 						<tr>
-							<td style="vertical-align: middle;"><%= l order.created_at %></td>
+							<td style="vertical-align: middle;"><%= l(order.created_at, format: :short) %></td>
 							<td><%= order.shipping_postal_code %><br>
 								<%= order.shipping_address %><br>
 								<%= order.shipping_name %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -9,7 +9,7 @@
 			<table border="1" style="width: 500px;">
 				<tr>
 					<td style="padding: 5px;">注文日</td>
-					<td style="padding: 5px;"><%= l @order.created_at %></td>
+					<td style="padding: 5px;"><%= l(@order.created_at, format: :short) %></td>
 				</tr>
 				<tr>
 					<td style="padding: 5px;">配送先</td>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,4 @@
 ja:
   time:
     formats:
-      default: "%Y/%m/%d %H:%M:%S"
+      default: "%Y/%m/%d"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,5 @@
 ja:
   time:
     formats:
-      default: "%Y/%m/%d"
+      default: "%Y/%m/%d %H:%M:%S"
+      short: "%Y/%m/%d"


### PR DESCRIPTION
日付表記デフォルト変更

変更ファイル
・config/locales/ja.yml
・app/views/orders/index.html.erb
・app/views/orders/show.html.erb

Orderのviewページ(index/show)日付のみに記述訂正済み
管理者側の注文履歴一覧ページはそのまま時間が表示されるようになってます。